### PR TITLE
Fixed metadata tag stripping bug

### DIFF
--- a/osj-project/pages/templates/pages/page.html
+++ b/osj-project/pages/templates/pages/page.html
@@ -3,9 +3,16 @@
 
 {% block scripts %}
     <meta property="og:title" content="OpenJewelry - {{ page.title }}" />
-    <meta property="og:description" content="{{ page.content | slice:'0:100'}}" />
+    <meta property="og:description" content="{{ page.content | slice:'0:100'|striptags }}" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://{{ request.get_host }}{% static 'pages/osj-logo-full.png' %}" />
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta property="twitter:domain" content="{{ request.get_host }}">
+    <meta property="twitter:url" content="https://{{ request.get_host }}{{ request.get_full_path }}">
+    <meta name="twitter:title" content="OpenJewelry - {{ page.title }}">
+    <meta name="twitter:description" content="{{ page.content | slice:'0:100'|striptags }}">
+    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'pages/osj-logo-full.png' %}">
 {% endblock %}
 
     {% block content %}

--- a/osj-project/things/templates/things/jewelry.html
+++ b/osj-project/things/templates/things/jewelry.html
@@ -74,9 +74,10 @@
                 window.scrollTo(0, document.getElementById(tab).offsetTop);
             };
         </script>
+
     <meta property="og:url" content="https://{{ request.get_host }}{{ request.get_full_path }}" />
     <meta property="og:title" content="OpenJewelry - {{ piece.title }}" />
-    <meta property="og:description" content="{{ piece.description | slice:'0:100'}}" />
+    <meta property="og:description" content="{{ piece.description | slice:'0:100'|striptags }}" />
     <meta property="og:type" content="website" />
     {% if featuredImage.image %}
         <meta property="og:image" content="https://{{ request.get_host }}{{ featuredImage.image.url }}" />
@@ -90,7 +91,7 @@
     <meta property="twitter:domain" content="{{ request.get_host }}">
     <meta property="twitter:url" content="https://{{ request.get_host }}{{ request.get_full_path }}">
     <meta name="twitter:title" content="OpenJewelry - {{ piece.title }}">
-    <meta name="twitter:description" content="{{ piece.description | slice:'0:100'}}">
+    <meta name="twitter:description" content="{{ piece.description | slice:'0:100'|striptags }}">
 
     {% endblock %}
 


### PR DESCRIPTION
links in metadata were causing a quotation mark to show up mid-tag, which terminated the string and rendered part of the tag at the top of the page. Escaped descriptions in the django template while rendering